### PR TITLE
Create initial documentation for key components

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,2 @@
+# Documentation
+This directory contains documentation for the project.

--- a/docs/agent-manager-main.md
+++ b/docs/agent-manager-main.md
@@ -1,0 +1,75 @@
+# agent-manager/src/main.py
+
+## Overview
+
+This script is the main entry point for the Agent Manager service. It sets up and runs a gRPC server that allows clients to execute and manage browser-based AI agents. The service handles the lifecycle of these agents, including starting browser instances, initializing the agent with appropriate configurations (LLM provider, model, etc.), managing agent state, and streaming results back to the client. It also interacts with a PostgreSQL database to persist session information and agent state.
+
+## Key Components
+
+- `AgentManagerServicer`: The core class that implements the gRPC `AgentManagerService`. It contains the logic for handling agent execution requests.
+  - `RunAgent(request, context)`: Handles non-streaming requests to run an agent. It starts a browser, initializes the agent, runs it with the given prompt, and returns the final result.
+  - `RunAgentStream(request, context)`: Handles streaming requests to run an agent. This method allows for real-time updates and interaction with the agent, yielding chunks of data (steps, final output, errors, timeouts) as they occur. It can reuse existing browser sessions for chat-like interactions.
+  - `_init_agent(...)`: A helper method responsible for creating and configuring an `Agent` instance. It sets up the browser connection (CDP URL), selects the LLM provider (Anthropic, Bedrock, OpenAI, Gemini), and other agent parameters.
+  - `_run_agent(...)`: A private helper method that synchronously executes the agent's main `run` logic and formats the output.
+  - `_update_agent_session(...)`: Updates or inserts agent session details (CDP URL, VNC URL, machine ID) into the database.
+  - `_update_agent_machine_status(...)`: Updates the status of the browser machine (e.g., "running", "stopped") in the database.
+  - `_update_agent_state(...)`: Saves the agent's internal state to the database.
+  - `_update_agent_status(...)`: Updates the agent's operational status (e.g., "idle", "working") in the database.
+  - `_get_agent_state(...)`: Retrieves the last saved state for an agent from the database.
+  - `_get_agent_chat_session(...)`: Retrieves comprehensive session details by joining data from `agent_sessions` and `agent_chats` tables.
+- `serve()`: An asynchronous function that initializes the global database connection (`db_conn`) and starts the gRPC server, making it listen for incoming requests on the configured port.
+
+## Important Variables/Constants
+
+- `logger`: A standard Python `logging.Logger` instance used for logging messages throughout the application.
+- `port`: The network port on which the gRPC server listens. It defaults to "8901" and can be overridden by the `PORT` environment variable.
+- `scrapybara`: An instance of the `Scrapybara` client, used to start, stop, and manage browser instances that the agents will control.
+- `db_conn`: An `asyncpg.Connection` object representing the connection to the PostgreSQL database. It is initialized in the `serve()` function.
+
+## Usage Examples
+
+This script is typically run as a standalone server:
+
+```bash
+python agent-manager/src/main.py
+```
+
+Clients would then connect to this server using a gRPC client generated from the corresponding `.proto` file (e.g., `agent_manager_grpc_pb2_grpc`). The client would call `RunAgent` or `RunAgentStream` methods.
+
+Example (conceptual client-side Python):
+```python
+# import grpc
+# import agent_manager_grpc_pb2
+# import agent_manager_grpc_pb2_grpc
+
+# channel = grpc.insecure_channel('localhost:8901')
+# stub = agent_manager_grpc_pb2_grpc.AgentManagerServiceStub(channel)
+
+# request = agent_manager_grpc_pb2.RunAgentRequest(
+#     session_id="some-session-id",
+#     prompt="Navigate to example.com and find the title.",
+#     model_provider=agent_manager_grpc_pb2.ModelProvider.ANTHROPIC, # Enum value
+#     model="claude-3-opus-20240229"
+# )
+# response = stub.RunAgent(request)
+# print(response.result.content)
+```
+
+## Dependencies and Interactions
+
+- **gRPC (`grpcio`)**: Used for defining and running the main service API. The script implements a service defined in protobuf (likely `agent_manager_grpc.proto`).
+- **AsyncPG (`asyncpg`)**: Used for asynchronous communication with a PostgreSQL database to store and manage agent sessions, state, and status.
+- **DotEnv (`python-dotenv`)**: Used to load environment variables (e.g., `DATABASE_URL`, `SCRAPYBARA_API_KEY`, `PORT`) from a `.env` file.
+- **Laminar (`lmnr`)**: Used for distributed tracing and observability. It can deserialize parent span contexts from requests.
+- **Scrapybara (`scrapybara`)**: Used to manage the lifecycle of browser instances (start, stop, get CDP URL) that the agents use for web interaction.
+- **Internal Modules**:
+    - `agent_manager_grpc_pb2` and `agent_manager_grpc_pb2_grpc`: Generated Python code from protobuf definitions, providing the gRPC message types and service stubs/servers.
+    - `index` (specifically `index.Agent`, `index.agent.agent` and provider classes like `AnthropicProvider`): Contains the core `Agent` logic, data structures for agent communication (e.g., `StepChunk`), and implementations for different LLM providers.
+- **Environment Variables**:
+    - `PORT`: Defines the port for the gRPC server.
+    - `SCRAPYBARA_API_KEY`: API key for the Scrapybara service.
+    - `DATABASE_URL`: Connection string for the PostgreSQL database.
+    - `BACKEND_URL`, `BACKEND_HTTP_PORT`, `BACKEND_GRPC_PORT`: Potentially for Laminar or other backend service communication.
+- **Database**: The script heavily relies on a PostgreSQL database with tables like `agent_sessions` and `agent_chats` to persist and manage agent-related data.
+- **LLM Providers**: Interacts with various LLM providers (Anthropic, OpenAI, Google Gemini, AWS Bedrock) through the `Agent` class, which abstracts the specific provider logic.
+```

--- a/docs/app-server-db-projects.md
+++ b/docs/app-server-db-projects.md
@@ -1,0 +1,95 @@
+# app-server/src/db/projects.rs
+
+## Overview
+
+This file is responsible for all database operations related to "projects" within the application. It provides functions for creating new projects, retrieving existing projects by their ID, and deleting projects. A key feature of project creation is an integrated authorization check to ensure that the user attempting to create a project is a member of the specified workspace.
+
+## Key Components
+
+- `struct Project`: Represents a project entity in the database.
+    - `id: Uuid`: The unique identifier for the project.
+    - `name: String`: The name of the project.
+    - `workspace_id: Uuid`: The unique identifier of the workspace to which this project belongs.
+    It derives `Deserialize`, `Serialize` (for JSON conversion), `FromRow` (for `sqlx` row mapping), and `Clone`.
+
+- `async fn get_project(pool: &PgPool, project_id: &Uuid) -> Result<Project>`:
+    Retrieves a single project from the database based on its unique `project_id`. Returns a `Result` containing the `Project` if found, or an error.
+
+- `async fn create_project(pool: &PgPool, user_id: &Uuid, name: &str, workspace_id: Uuid) -> Result<Project>`:
+    Creates a new project in the database.
+    - Parameters:
+        - `pool`: A reference to the `sqlx::PgPool` for database access.
+        - `user_id`: The ID of the user attempting to create the project. This is used for an authorization check.
+        - `name`: The desired name for the new project.
+        - `workspace_id`: The ID of the workspace where the project will be created.
+    - Logic: It attempts to insert a new project only if the provided `user_id` is found as a member of the given `workspace_id` in the `members_of_workspaces` table. If successful, it returns the newly created `Project`.
+
+- `async fn delete_project(pool: &PgPool, project_id: &Uuid) -> Result<()>`:
+    Deletes a project from the database based on its `project_id`. Returns a `Result` indicating success or failure.
+
+## Important Variables/Constants
+
+Not applicable for this file, as configurations are primarily passed as function arguments or are implicit in SQL queries. The fields of the `Project` struct are the main data points.
+
+## Usage Examples
+
+Conceptual examples of how these functions might be used by other parts of the application (e.g., API handlers):
+
+```rust
+// Assuming 'db_pool' is an available &PgPool and 'user_id', 'project_id', 'workspace_id' are Uuids.
+
+// Example: Creating a new project
+// let new_project_name = "My Awesome Project";
+// let target_workspace_id = Uuid::new_v4();
+// let current_user_id = Uuid::new_v4();
+//
+// match db::projects::create_project(&db_pool, &current_user_id, new_project_name, target_workspace_id).await {
+//     Ok(project) => {
+//         // Use the created project
+//         println!("Created project: {}", project.name);
+//     }
+//     Err(e) => {
+//         // Handle error, e.g., user not member of workspace or other DB error
+//         eprintln!("Failed to create project: {}", e);
+//     }
+// }
+
+// Example: Retrieving a project
+// let project_to_find = Uuid::new_v4();
+//
+// match db::projects::get_project(&db_pool, &project_to_find).await {
+//     Ok(project) => {
+//         println!("Found project: {}", project.name);
+//     }
+//     Err(e) => {
+//         eprintln!("Failed to get project: {}", e);
+//     }
+// }
+
+// Example: Deleting a project
+// let project_to_delete = Uuid::new_v4();
+//
+// match db::projects::delete_project(&db_pool, &project_to_delete).await {
+//     Ok(()) => {
+//         println!("Project deleted successfully.");
+//     }
+//     Err(e) => {
+//         eprintln!("Failed to delete project: {}", e);
+//     }
+// }
+```
+
+## Dependencies and Interactions
+
+- **`sqlx`**: Used extensively for all asynchronous PostgreSQL database interactions.
+    - `PgPool`: For connection pooling.
+    - `FromRow`: Trait used to map query results directly to the `Project` struct.
+    - `query_as!`, `query!`: Macros/functions for executing typed SQL queries.
+- **`serde`**: Used for `Serialize` and `Deserialize` traits on the `Project` struct, allowing it to be easily converted to/from formats like JSON, typically for API responses/requests.
+- **`uuid::Uuid`**: Used for project and workspace identifiers.
+- **`anyhow::Result`**: Standardized error handling mechanism for function return types.
+- **Database Schema**: Interacts with at least two tables:
+    - `projects`: The primary table for storing project data (id, name, workspace_id).
+    - `members_of_workspaces`: Used by `create_project` to verify that the user creating the project is a member of the target workspace.
+- **API Handlers**: These database functions are intended to be called by higher-level logic, most likely API route handlers within the `app-server` (e.g., in `app-server/src/routes/` or `app-server/src/api/`) that manage project-related HTTP requests.
+```

--- a/docs/app-server-main.md
+++ b/docs/app-server-main.md
@@ -1,0 +1,118 @@
+# app-server/src/main.rs
+
+## Overview
+
+The `app-server/src/main.rs` file serves as the primary entry point and orchestrator for the application server. It is responsible for initializing a wide array of services and configurations, setting up database connections (PostgreSQL and ClickHouse), message queues (RabbitMQ or Tokio MPSC channels based on feature flags), caching mechanisms (Redis or in-memory), object storage (AWS S3 or a mock implementation), and clients for external gRPC services like Agent Manager and Machine Manager.
+
+The application starts by loading environment variables, initializing cryptographic libraries and logging. It then establishes shared resources like database pools and message queue connections. Two main server components are launched in separate threads:
+1.  An **Actix HTTP server**: Handles REST API requests, serves various endpoints for workspaces, projects, traces, datasets, evaluations, etc. It also spawuls multiple background Tokio tasks (workers) to process messages from different queues (e.g., spans, browser events, evaluators) asynchronously.
+2.  A **Tonic gRPC server**: Primarily handles gRPC services, with a key example being the `TraceServiceServer` for ingesting trace data.
+
+Feature flags heavily influence the application's setup, allowing components like full message queueing, S3 storage, and external service integrations to be conditionally compiled or enabled.
+
+## Key Components
+
+- `main()`: The core function that orchestrates the entire application startup. It performs:
+    - Initialization of `sodiumoxide` and `rustls` crypto providers.
+    - Loading of environment variables via `dotenv`.
+    - Setup of `env_logger`.
+    - Parsing of critical configurations like payload limits and port numbers from environment variables.
+    - Initialization of shared application state:
+        - **Cache**: `RedisCache` if `REDIS_URL` is set, otherwise `InMemoryCache`.
+        - **Database (PostgreSQL)**: `sqlx::postgres::PgPool` connected via `DATABASE_URL`.
+        - **Message Queues**:
+            - `spans_message_queue`: RabbitMQ (`lapin`) if `Feature::FullBuild` is enabled and `RABBITMQ_URL` is set, otherwise `mq::tokio_mpsc::TokioMpscQueue`.
+            - `browser_events_message_queue`: Similar setup as spans MQ.
+            - `evaluators_message_queue`: Similar setup as spans MQ.
+            - `agent_manager_workers`: A dedicated MPSC-based worker queue for agent tasks.
+        - **Storage (S3)**: `storage::s3::S3Storage` if `Feature::Storage` is enabled, using `AWS_SDK_CONFIG` and `S3_TRACE_PAYLOADS_BUCKET`. Otherwise, `storage::mock::MockStorage`.
+        - **ClickHouse Client**: Configured via `CLICKHOUSE_URL`, `CLICKHOUSE_USER`, and `CLICKHOUSE_PASSWORD`.
+        - **MachineManager Client**: `MachineManagerServiceClient` (gRPC) if `Feature::MachineManager` is enabled, connecting to `MACHINE_MANAGER_URL_GRPC`. Otherwise, a mock manager.
+        - **AgentManager Client**: `AgentManagerServiceClient` (gRPC) if `Feature::AgentManager` is enabled, connecting to `AGENT_MANAGER_URL`. Otherwise, a mock manager.
+        - **HTTP Client for Evaluators**: `reqwest::Client` configured for online evaluators if `Feature::Evaluators` is enabled.
+    - Spawning a new thread for the Actix `HttpServer`.
+    - Spawning a new thread for the Tonic `Server` (gRPC).
+    - Waits for these server threads to complete.
+
+- `HttpServer::new(...)` (within the HTTP server thread): Configures the Actix web server. This includes:
+    - Wrapping with middleware: `Logger` (for request logging), `NormalizePath` (for URL normalization), and `HttpAuthentication` (for bearer token auth using `auth::validator` and `auth::project_validator`).
+    - Setting application-level data (`app_data`) like payload size limits (`JsonConfig`, `PayloadConfig`), and shared `Arc`-wrapped instances of the cache, DB pool, message queues, ClickHouse client, storage, service managers, etc.
+    - Registering numerous API routes defined in `api::v1::*` and `routes::*` modules, organized under scopes like `/v1`, `/api/v1/workspaces`, `/api/v1/projects/{project_id}`, etc.
+    - Spawning background Tokio tasks using `tokio::spawn` for processing messages from `spans_mq_for_http`, `browser_events_message_queue`, and `evaluators_message_queue`. These workers interact with the database, cache, ClickHouse, and external evaluator services.
+
+- `Server::builder()` (within the gRPC server thread): Configures the Tonic gRPC server. This includes:
+    - Adding the `TraceServiceServer` (from `traces::grpc_service::ProcessTracesService`) which uses the shared DB, cache, and spans message queue.
+    - Enabling Gzip compression and setting message size limits.
+    - Setting up a graceful shutdown mechanism triggered by `wait_stop_signal`.
+
+- **Modules**: The `main.rs` file heavily relies on a modular architecture, utilizing numerous internal modules such as:
+    - `db`: Database interaction logic.
+    - `mq`: Message queue abstractions and implementations (RabbitMQ, Tokio MPSC).
+    - `cache`: Caching abstractions and implementations (Redis, InMemory).
+    - `storage`: Object storage abstractions (S3, Mock).
+    - `agent_manager`, `machine_manager`: Clients and mocks for external gRPC services.
+    - `api::v1::*`, `routes::*`: HTTP route handlers and API definitions.
+    - `features`: Feature flag management.
+    - `traces`, `browser_events`, `evaluators`: Logic for processing specific types of asynchronous tasks.
+    - `auth`: Authentication logic.
+    - `runtime`: Tokio runtime creation.
+
+## Important Variables/Constants
+
+Many configuration values are loaded from environment variables. Key ones include:
+- `RUST_LOG`: Controls logging verbosity.
+- `HTTP_PAYLOAD_LIMIT`: Max size for HTTP request bodies (defaults to 5MB).
+- `GRPC_PAYLOAD_LIMIT`: Max size for gRPC messages (defaults to 25MB).
+- `PORT`: Listening port for the HTTP server (defaults to 8000).
+- `GRPC_PORT`: Listening port for the gRPC server (defaults to 8001).
+- `REDIS_URL`: If provided, Redis is used for caching; otherwise, an in-memory cache is used.
+- `DATABASE_URL`: Connection string for the PostgreSQL database.
+- `DATABASE_MAX_CONNECTIONS`: Maximum number of connections in the PostgreSQL pool.
+- `RABBITMQ_URL`: Connection string for RabbitMQ. Used if `Feature::FullBuild` is enabled.
+- `AWS_REGION`: AWS region for services like S3.
+- `S3_TRACE_PAYLOADS_BUCKET`: Name of the S3 bucket for storing trace payloads. Used if `Feature::Storage` is enabled.
+- `CLICKHOUSE_URL`, `CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD`: Credentials for ClickHouse database.
+- `MACHINE_MANAGER_URL_GRPC`: gRPC endpoint for the Machine Manager service.
+- `AGENT_MANAGER_URL`: gRPC endpoint for the Agent Manager service.
+- `ONLINE_EVALUATORS_SECRET_KEY`, `PYTHON_ONLINE_EVALUATOR_URL`: Configuration for evaluator services.
+- `NUM_SPANS_WORKERS_PER_THREAD`, `NUM_BROWSER_EVENTS_WORKERS_PER_THREAD`, `NUM_EVALUATORS_WORKERS_PER_THREAD`: Number of background workers spawned for each queue type within the HTTP server.
+
+## Usage Examples
+
+This file compiles into the main binary for the application server. It is typically run directly after building:
+
+```bash
+# (Assuming the binary is named app-server)
+./app-server
+```
+
+Command-line arguments are not explicitly parsed by this `main.rs`; configuration is primarily through environment variables.
+
+## Dependencies and Interactions
+
+- **Web Framework**: `actix-web` for the HTTP server, `actix-web-httpauth` for authentication.
+- **gRPC Framework**: `tonic` for the gRPC server.
+- **Database**:
+    - `sqlx` (specifically `sqlx::postgres`) for asynchronous PostgreSQL operations.
+    - `clickhouse` client for interacting with a ClickHouse database.
+- **Message Queues**:
+    - `lapin` for RabbitMQ communication (if `Feature::FullBuild` is enabled).
+    - `tokio::sync::mpsc` for local, in-process messaging as a fallback or for specific internal queues.
+- **Caching**:
+    - `redis` crate for connecting to a Redis server.
+    - Internal `InMemoryCache` as an alternative.
+- **Cloud Services**:
+    - `aws-config` and `aws-sdk-s3` for interacting with AWS S3 for object storage.
+- **HTTP Client**: `reqwest` for making outbound HTTP calls (e.g., to evaluator services).
+- **Service Clients (gRPC)**:
+    - `AgentManagerServiceClient` for `agent-manager`.
+    - `MachineManagerServiceClient` for `machine-manager`.
+    (These are generated by Tonic from `.proto` definitions, likely within their respective modules).
+- **Concurrency**: `tokio` for the asynchronous runtime, `std::thread` for separating the HTTP and gRPC server execution environments.
+- **Configuration**: `dotenv` for loading `.env` files.
+- **Logging**: `env_logger` and `log` facade.
+- **Cryptography**: `sodiumoxide` for general cryptographic functions, `rustls` for TLS.
+- **Feature Flags**: A custom `features` module (e.g., `is_feature_enabled(Feature::X)`) is used to conditionally compile or enable different components (e.g., using mock services vs. real clients, S3 vs. mock storage).
+- **Internal Modules**: The application is heavily modularized. `main.rs` integrates functionalities from modules like `db`, `mq`, `cache`, `storage`, `api`, `routes`, `traces`, `browser_events`, `evaluators`, `agent_manager`, `machine_manager`, `auth`, `runtime`, etc.
+- **Orchestration**: `main()` initializes and holds `Arc` (Atomically Referenced Counter) handles to shared resources like database pools, cache instances, and message queue producers/consumers. These are then cloned and passed into the Actix application state (for HTTP handlers and workers) and the Tonic service constructors (for gRPC services). This ensures safe concurrent access to shared state.
+```

--- a/docs/frontend-lib-sql-transpile.md
+++ b/docs/frontend-lib-sql-transpile.md
@@ -1,0 +1,113 @@
+# frontend/lib/sql/transpile.ts
+
+## Overview
+
+This TypeScript module provides a robust system for validating and transpiling user-submitted SQL queries. The primary goal is to ensure that these queries are safe and operate within predefined constraints before execution. Key functionalities include:
+
+1.  Restricting queries to `SELECT` statements only.
+2.  Enforcing access to a whitelist of allowed tables (`ALLOWED_TABLES`).
+3.  Automatically injecting a `project_id` filter into `WHERE` clauses to enforce data isolation and security.
+4.  Providing syntactic sugar for querying JSONB fields, abstracting the underlying SQL complexities.
+5.  Applying a default query limit (e.g., `LIMIT 100`) if not specified by the user, to prevent performance issues.
+6.  Adding predefined Common Table Expressions (CTEs) to enhance query capabilities.
+
+The module also includes a function `executeSafeQuery` to run these validated and transpiled queries against a PostgreSQL database using Drizzle ORM.
+
+## Key Components
+
+-   `class SQLValidator`:
+    The core class orchestrating the parsing, validation, and transpilation process.
+    -   `constructor(allowedTables: Set<string> = ALLOWED_TABLES)`: Initializes the validator. It uses `node-sql-parser` for AST manipulation and takes an optional set of `allowedTables`.
+    -   `validateAndTranspile(sqlQuery: string, projectId: string): TranspiledQuery`: The main public method. It takes a raw SQL query string and the current user's `projectId`. It parses the query, validates it against security and structural rules, modifies the Abstract Syntax Tree (AST) to enforce constraints and add features, and then converts the AST back to a SQL string. The result includes the SQL, arguments, validity status, and any errors or warnings.
+    -   `private isSelectQuery(ast: AST | AST[]): boolean`: Checks if the parsed AST represents only `SELECT` queries.
+    -   `private transpileQuery(ast: AST | AST[], projectId: string): { sql: string; args: Arg[]; warnings?: string[] }`: Modifies the input AST. It incorporates additional CTEs, applies a default limit, and calls `processSubqueries` for in-depth AST manipulation.
+    -   `private processSubqueries(node: AST, processedNodes: Set<AST>): AST`: A recursive function that traverses the query AST. For each `SELECT` node (including subqueries and CTEs), it performs several transformations:
+        -   Applies automatic join rules (via `applyAutoJoinRules`).
+        -   Qualifies column names with table aliases or names (via `qualifyColumnReferences`).
+        -   Rewrites JSONB field access to standard SQL (via `replaceJsonbFields`).
+        -   Recursively processes nested structures like CTEs, `FROM` clause subqueries, and expressions in `WHERE` clauses.
+        -   Injects the `project_id` filter into the `WHERE` clause of the current `SELECT` statement (via `applyProjectIdToStatement`), targeting its main table.
+
+-   `async function executeSafeQuery(sqlQuery: string, projectId: string, logger: Logger = new NoopLogger()): Promise<{ result: Record<string, any>[]; warnings?: string[] }>`:
+    A utility function that creates an `SQLValidator` instance, calls `validateAndTranspile` on the input query and `projectId`. If the transpilation is successful, it executes the generated SQL using a Drizzle ORM `PostgresJsPreparedQuery` with the provided `projectId` as a parameter. It returns the query results and any warnings.
+
+-   `interface TranspiledQuery` (imported from `./types`):
+    Defines the structure of the return value from `validateAndTranspile`. It typically includes:
+    -   `valid: boolean`: Whether the transpilation was successful.
+    -   `sql: string | null`: The transpiled SQL string, or null if invalid.
+    -   `args: Arg[]`: An array of arguments for the prepared statement (e.g., `project_id`).
+    -   `error: string | null`: An error message if validation or transpilation failed.
+    -   `warnings?: string[]`: Any warnings generated during transpilation (e.g., default limit applied).
+
+-   `ALLOWED_TABLES: Set<string>` (imported from `./types`):
+    A predefined set of table names that users are permitted to query.
+
+-   `ADDITIONAL_WITH_CTES: any[]` (imported from `./with`):
+    An array of AST structures representing CTEs that are automatically prepended to user queries.
+
+## Important Variables/Constants
+
+-   `ALLOWED_TABLES`: As described above, critical for security by restricting table access.
+-   `ADDITIONAL_WITH_CTES`: Extends query capabilities by injecting common table expressions.
+-   Default query limit: A hardcoded limit (e.g., 100) is applied if the user doesn't specify one, primarily for performance control.
+
+## Usage Examples
+
+```typescript
+// Conceptual example of using SQLValidator and executeSafeQuery
+
+import { SQLValidator, executeSafeQuery } from './transpile'; // Assuming correct path
+import { db } from '@/lib/db/drizzle'; // For executeSafeQuery
+import { Logger } from 'drizzle-orm';
+
+const userQuery = "SELECT id, name, details->>'fieldName' AS field FROM events WHERE status = 'active' ORDER BY created_at DESC";
+const currentProjectId = "project_abc123";
+
+// Using SQLValidator directly:
+const validator = new SQLValidator();
+const transpiledOutput = validator.validateAndTranspile(userQuery, currentProjectId);
+
+if (transpiledOutput.valid && transpiledOutput.sql) {
+  console.log("Transpiled SQL:", transpiledOutput.sql);
+  console.log("Arguments:", transpiledOutput.args);
+  if (transpiledOutput.warnings) {
+    console.warn("Warnings:", transpiledOutput.warnings.join('\n'));
+  }
+  // transpiledOutput.sql could then be passed to a database execution function
+  // that handles prepared statements with named arguments or positional parameters.
+} else {
+  console.error("SQL Error:", transpiledOutput.error);
+}
+
+// Using executeSafeQuery:
+async function runUserQuery() {
+  try {
+    // Assuming 'db' is your Drizzle client instance and 'logger' is a Drizzle logger
+    const { result, warnings } = await executeSafeQuery(userQuery, currentProjectId, /* logger */);
+    console.log("Query Results:", result);
+    if (warnings) {
+      console.warn("Execution Warnings:", warnings.join('\n'));
+    }
+  } catch (error) {
+    console.error("Failed to execute query:", error.message);
+  }
+}
+
+// runUserQuery();
+```
+
+## Dependencies and Interactions
+
+-   **`node-sql-parser`**: The core external library used for parsing SQL strings into an Abstract Syntax Tree (AST) and for converting the modified AST back into a SQL string.
+-   **`drizzle-orm` / `drizzle-orm/postgres-js`**: Used by `executeSafeQuery` to create and execute prepared SQL statements against a PostgreSQL database.
+-   **`@/lib/db/drizzle`**: Provides the application's configured Drizzle database client (`db`) used by `executeSafeQuery`.
+-   **Internal Helper Modules (within `frontend/lib/sql/`)**:
+    -   `./types`: Provides shared type definitions like `TranspiledQuery`, `Arg`, and the `ALLOWED_TABLES` constant.
+    -   `./expression` (`getExpressionASTs`): Utilities for working with expression nodes in the AST.
+    -   `./join` (`applyAutoJoinRules`, `qualifyColumnReferences`): Functions to modify the AST by adding necessary joins and ensuring column references are unambiguous.
+    -   `./project-id-filter` (`applyProjectIdToStatement`, `findMainTable`): Logic to find the appropriate place in the AST to inject the `project_id` filter and perform the injection.
+    -   `./replace` (`replaceJsonbFields`): Handles the transformation of custom JSONB field access syntax into standard SQL.
+    -   `./utils` (`getFromTableNames`): General utility functions for inspecting or manipulating the AST.
+    -   `./with` (`ADDITIONAL_WITH_CTES`): Supplies predefined CTE definitions to be merged into the user's query AST.
+-   **Consumers**: This module is likely consumed by backend API endpoints or services within the frontend's server-side logic that receive user-defined queries (e.g., from a custom query builder UI or a direct SQL input field). It acts as a security and transformation layer before database execution.
+```


### PR DESCRIPTION
This commit introduces a `docs` directory and provides initial Markdown documentation for a selection of significant files across the agent-manager, app-server, and frontend projects.

The documented files include:
- `agent-manager/src/main.py`: Covers the gRPC server for agent management.
- `app-server/src/main.rs`: Details the main application server setup.
- `app-server/src/db/projects.rs`: Explains database operations for projects.
- `frontend/lib/sql/transpile.ts`: Describes the SQL validation, transpilation, and execution logic.

This effort aims to provide a foundation for more comprehensive project documentation, focusing on overview, key components, dependencies, and usage examples for each file.